### PR TITLE
Fix NVMe legacy partition device node names

### DIFF
--- a/ansible/roles/01-system-prep/defaults/main.yml
+++ b/ansible/roles/01-system-prep/defaults/main.yml
@@ -18,9 +18,10 @@ zfsprep_root_disks:
   - sdb
 zfsprep_root_disks_by_id: "{{ zfsprep_root_disks | map('extract', hostvars[inventory_hostname]['ansible_devices'], ['links', 'ids', 0]) | list | map('regex_replace', '(.*)', '/dev/disk/by-id/\\g<1>') | list }}"
 zfsprep_root_device_list: "{{ zfsprep_legacy_device_nodes | ternary((zfsprep_root_disks | map('regex_replace', '(.*)', '/dev/\\g<1>') | list), zfsprep_root_disks_by_id) }}"
-zfsprep_efi_part_append: "{{ zfsprep_legacy_device_nodes | ternary('1', '-part1') }}"
-zfsprep_boot_part_append: "{{ zfsprep_legacy_device_nodes | ternary('2', '-part2') }}"
-zfsprep_root_part_append: "{{ zfsprep_legacy_device_nodes | ternary('3', '-part3') }}"
+zfsprep_nvme_p: "{{ zfsprep_root_disks[0].startswith('nvme') | ternary('p', '') }}"
+zfsprep_efi_part_append: "{{ zfsprep_legacy_device_nodes | ternary(zfsprep_nvme_p + '1', '-part1') }}"
+zfsprep_boot_part_append: "{{ zfsprep_legacy_device_nodes | ternary(zfsprep_nvme_p + '2', '-part2') }}"
+zfsprep_root_part_append: "{{ zfsprep_legacy_device_nodes | ternary(zfsprep_nvme_p + '3', '-part3') }}"
 
 zfsprep_mbr_partition_flags: "-a1 -n2:34:2047 -t2:EF02"
 zfsprep_efi_partition_flags: "-n1:1M:+512M -t1:EF00"

--- a/ansible/roles/02-chroot/defaults/main.yml
+++ b/ansible/roles/02-chroot/defaults/main.yml
@@ -15,9 +15,9 @@ zfsprep_grub_cmdline: "elevator=noop"
 zfsprep_root_disks_by_id: "{{ zfsprep_root_disks | map('extract', hostvars[inventory_hostname]['ansible_devices'], ['links', 'ids', 0]) | list | map('regex_replace', '(.*)', '/dev/disk/by-id/\\g<1>') | list }}"
 zfsprep_root_device_list: "{{ zfsprep_legacy_device_nodes | ternary((zfsprep_root_disks | map('regex_replace', '(.*)', '/dev/\\g<1>') | list), zfsprep_root_disks_by_id) }}"
 zfsprep_legacy_device_nodes: false
-zfsprep_efi_part_append: "{{ zfsprep_legacy_device_nodes | ternary('1', '-part1') }}"
-zfsprep_boot_part_append: "{{ zfsprep_legacy_device_nodes | ternary('2', '-part2') }}"
-zfsprep_root_part_append: "{{ zfsprep_legacy_device_nodes | ternary('3', '-part3') }}"
+zfsprep_efi_part_append: "{{ zfsprep_legacy_device_nodes | ternary(zfsprep_nvme_p + '1', '-part1') }}"
+zfsprep_boot_part_append: "{{ zfsprep_legacy_device_nodes | ternary(zfsprep_nvme_p + '2', '-part2') }}"
+zfsprep_root_part_append: "{{ zfsprep_legacy_device_nodes | ternary(zfsprep_nvme_p + '3', '-part3') }}"
 zfsprep_extra_locales: []
 zfsprep_lang: "en_US.UTF-8"
 zfsprep_locales: "{{ zfsprep_extra_locales + [zfsprep_lang] }}"


### PR DESCRIPTION
The legacy partition device names for drives `nvme0n1`, `nvme1n1` look like `nvme0n1p1`, `nvme1n1p1`. The `p` had been missing